### PR TITLE
MINIFICPP-1446 fix build on gentoo

### DIFF
--- a/cmake/BundledOSSPUUID.cmake
+++ b/cmake/BundledOSSPUUID.cmake
@@ -21,8 +21,8 @@ function(use_bundled_osspuuid SOURCE_DIR BINARY_DIR)
     message("Using bundled ossp-uuid")
 
     # Define patch step
-    set(PC "${Patch_EXECUTABLE}" -p1 -i "${SOURCE_DIR}/thirdparty/ossp-uuid/ossp-uuid-mac-fix.patch" &&
-           "${Patch_EXECUTABLE}" -p1 -i "${SOURCE_DIR}/thirdparty/ossp-uuid/ossp-uuid-no-prog.patch")
+    set(PC "${Patch_EXECUTABLE}" -p1 -N -r- -i "${SOURCE_DIR}/thirdparty/ossp-uuid/ossp-uuid-mac-fix.patch" &&
+           "${Patch_EXECUTABLE}" -p1 -N -r- -i "${SOURCE_DIR}/thirdparty/ossp-uuid/ossp-uuid-no-prog.patch" || :)
 
     # Define byproducts
     set(BYPRODUCTS "lib/libuuid.a"

--- a/extensions/sql/CMakeLists.txt
+++ b/extensions/sql/CMakeLists.txt
@@ -36,12 +36,7 @@ else()
 	# Build iODBC
 
 	# Define byproducts
-	if(NOT APPLE)
-		include(GNUInstallDirs)
-		set(IODBC_BYPRODUCT "${CMAKE_INSTALL_LIBDIR}/libiodbc.a")
-	else()
-		set(IODBC_BYPRODUCT "lib/libiodbc.a")
-	endif()
+	set(IODBC_BYPRODUCT "lib/libiodbc.a")
 
 	set(IODBC_BYPRODUCT_DIR "${CMAKE_CURRENT_BINARY_DIR}/thirdparty/iodbc-install/")
 


### PR DESCRIPTION
and workaround ossp-uuid patch reapplication issue by silently ignoring patch application errors in case the sources are already patched.
